### PR TITLE
Update the batch download info page link in emails

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -13,6 +13,6 @@ url_list_email_body_template = <html><body>\n\
 You have ordered: {0}.<br><br>\n\
 The file list that was ordered can be downloaded from:<br><br><a download href="{1}">{1}</a>.<br><br>\n\
 The files list includes paths to files which can be used to fetch the files via FTP, HTTP or rsync.<br><br>\n\
-Additional information on how to use the files list: <a href="https://paituli.csc.fi/ftprsync.html">ftp and rsync page</a>.<br><br>\n\
+Additional information on how to use the files list can be found from the <a href="https://paituli.csc.fi/files.html">batch download page</a>.<br><br>\n\
 Thank you for downloading from PaITuli.<br><br>\n\
 </body></html>

--- a/src/main/resources/messages_fi.properties
+++ b/src/main/resources/messages_fi.properties
@@ -13,6 +13,6 @@ url_list_email_body_template = <html><body>\n\
 Ladattava aineisto: {0}<br><br>\n\
 Tilaamasi tiedostolista on ladattavissa osoitteessa:<br><br><a download href="{1}">{1}</a>.<br><br>\n\
 Tiedostolista sisältää tiedostojen polut, joiden avulla voit ladata aineiston FTP:n, HTTP:n tai rsyncin avulla.<br><br>\n\
-Lisätietoja tiedostolistan käyttämisestä osoitteesta <a href=https://paituli.csc.fi/ftprsync.html>ftp- ja rsync-sivulta</a>.<br><br>\n\
+Lisätietoja tiedostolistan käyttämisestä löytyy <a href=https://paituli.csc.fi/files.html>massalataus-sivulta</a>.<br><br>\n\
 Kiitos lataustilauksestasi.<br><br>\n\
 </body></html>


### PR DESCRIPTION
* The link pointed to an outdated path
* Slightly adjusted wording too

to-do: 
- [ ] test emails on test server
- [ ] test emails on prod